### PR TITLE
fix: don't use int width for mysql > 8.0.17

### DIFF
--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -241,6 +241,14 @@ class MySQLSchemaManager extends DBSchemaManager
 
     protected static $_cache_collation_info = [];
 
+    public function shouldUseIntegerWidth()
+    {
+        // MySQL 8.0.17 stopped reporting the width attribute for integers
+        // https://github.com/silverstripe/silverstripe-framework/issues/9453
+        $v = $this->database->getVersion();
+        return version_compare($v,'8.0.17','<');
+    }
+
     public function fieldList($table)
     {
         $fields = $this->query("SHOW FULL FIELDS IN \"$table\"");
@@ -405,7 +413,8 @@ class MySQLSchemaManager extends DBSchemaManager
         //'default'=>$this->default);
         //DB::requireField($this->tableName, $this->name, "tinyint(1) unsigned not null default
         //'{$this->defaultVal}'");
-        return 'tinyint(1) unsigned not null' . $this->defaultClause($values);
+        $width = $this->shouldUseIntegerWidth() ? '(1)' : '';
+        return 'tinyint'.$width.' unsigned not null' . $this->defaultClause($values);
     }
 
     /**
@@ -518,7 +527,8 @@ class MySQLSchemaManager extends DBSchemaManager
         //For reference, this is what typically gets passed to this function:
         //$parts=Array('datatype'=>'int', 'precision'=>11, 'null'=>'not null', 'default'=>(int)$this->default);
         //DB::requireField($this->tableName, $this->name, "int(11) not null default '{$this->defaultVal}'");
-        return "int(11) not null" . $this->defaultClause($values);
+        $width = $this->shouldUseIntegerWidth() ? '(11)' : '';
+        return "int$width not null" . $this->defaultClause($values);
     }
 
     /**
@@ -534,8 +544,8 @@ class MySQLSchemaManager extends DBSchemaManager
         //             'arrayValue'=>$this->arrayValue);
         //$values=Array('type'=>'bigint', 'parts'=>$parts);
         //DB::requireField($this->tableName, $this->name, $values);
-
-        return 'bigint(20) not null' . $this->defaultClause($values);
+        $width = $this->shouldUseIntegerWidth() ? '(20)' : '';
+        return 'bigint'.$width.' not null' . $this->defaultClause($values);
     }
 
     /**
@@ -616,7 +626,8 @@ class MySQLSchemaManager extends DBSchemaManager
 
     public function IdColumn($asDbValue = false, $hasAutoIncPK = true)
     {
-        return 'int(11) not null auto_increment';
+        $width = $this->shouldUseIntegerWidth() ? '(11)' : '';
+        return 'int'.$width.' not null auto_increment';
     }
 
     /**


### PR DESCRIPTION
Fixes issue 9453:

Added function `shouldUseIntegerWidth()` to `MySQLSchemaManager` to check for MySQL version and used it in functions like `int()`, `bigint()`, `tinyint()` to determine whether the width attribute should be used for this mysql version.

Achieves the result described in the task.